### PR TITLE
Add list_accessible_calendars for Business Connect

### DIFF
--- a/cronofy.php
+++ b/cronofy.php
@@ -434,6 +434,11 @@ class Cronofy
         return $this->http_get("/" . self::API_VERSION . "/calendars");
     }
 
+    public function list_accessible_calendars($profileId)
+    {
+        $this->http_get("/" . self::API_VERSION . "/accessible_calendars", ['profile_id' => $profileId]);
+    }
+
     public function read_events($params)
     {
         /*
@@ -726,7 +731,7 @@ class Cronofy
             "participants" => $params["participants"],
             "required_duration" => $params["required_duration"]
         );
-        
+
         if (!empty($params["buffer"])) {
             $postfields["buffer"] = $params["buffer"];
         }
@@ -975,7 +980,7 @@ class Cronofy
 
         return $this->http_get("/" . self::API_VERSION . "/availability_rules/" . $availability_rule_id);
     }
-    
+
     public function list_availability_rules()
     {
 

--- a/cronofy.php
+++ b/cronofy.php
@@ -436,7 +436,7 @@ class Cronofy
 
     public function list_accessible_calendars($profileId)
     {
-        $this->http_get("/" . self::API_VERSION . "/accessible_calendars", ['profile_id' => $profileId]);
+        return $this->http_get("/" . self::API_VERSION . "/accessible_calendars", ['profile_id' => $profileId]);
     }
 
     public function read_events($params)

--- a/cronofy.php
+++ b/cronofy.php
@@ -436,7 +436,7 @@ class Cronofy
 
     public function list_accessible_calendars($profileId)
     {
-        return $this->http_get("/" . self::API_VERSION . "/accessible_calendars", ['profile_id' => $profileId]);
+        return $this->http_get("/" . self::API_VERSION . "/accessible_calendars", array('profile_id' => $profileId));
     }
 
     public function read_events($params)

--- a/cronofy.php
+++ b/cronofy.php
@@ -230,6 +230,7 @@ class Cronofy
           Array $params : An array of additional paramaters
           redirect_uri : String The HTTP or HTTPS URI you wish the user's authorization request decision to be redirected to. REQUIRED
           scope : An array of scopes to be granted by the access token. Possible scopes detailed in the Cronofy API documentation. REQUIRED
+          delegated_scope : Array. An array of scopes to be granted that will be allowed to be granted to the account's users. OPTIONAL
           state : String A value that will be returned to you unaltered along with the user's authorization request decision. OPTIONAL
           avoid_linking : Boolean when true means we will avoid linking calendar accounts together under one set of credentials. OPTIONAL
           link_token : String The link token to explicitly link to a pre-existing account. OPTIONAL
@@ -251,6 +252,9 @@ class Cronofy
         }
         if (!empty($params['link_token'])) {
             $url.="&link_token=" . $params['link_token'];
+        }
+        if (!empty($params['delegated_scope'])) {
+            $url.="&delegated_scope=" . rawurlencode(join(" ", $params['delegated_scope']));
         }
 
         return $url;

--- a/tests/AccessibleCalendarsTest.php
+++ b/tests/AccessibleCalendarsTest.php
@@ -1,0 +1,53 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class AccessibleCalendarsTest extends TestCase
+{
+    public function testListAccessibleCalendars()
+    {
+        $application_calendar_id = "foo";
+
+        $accessible_calendars_response = '{
+            "accessible_calendars": [
+                {
+                    "calendar_type": "resource",
+                    "email": "board-room-london@example.com",
+                    "name": "Board room (London)"
+                },
+                {
+                    "calendar_type": "unknown",
+                    "email": "jane.doe@example.com",
+                    "name": "Jane Doe"
+                },
+                {
+                    "calendar_type": "unknown",
+                    "email": "alpha.team@example.com",
+                    "name": "Alpha Team"
+                }
+            ]
+        }';
+
+        $http = $this->createMock('HttpRequest');
+        $http->expects($this->once())
+            ->method('http_get')
+            ->with(
+                'https://api.cronofy.com/v1/accessible_calendars?'
+                    . http_build_query(array('profile_id' => $profileId = 'profile-id')),
+                array(
+                    'Authorization: Bearer accessToken',
+                    'Host: api.cronofy.com',
+                )
+            )
+            ->willReturn(array($accessible_calendars_response, 200));
+
+        $cronofy = new Cronofy(array(
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ));
+
+        $cronofy->list_accessible_calendars($profileId);
+    }
+}

--- a/tests/AccessibleCalendarsTest.php
+++ b/tests/AccessibleCalendarsTest.php
@@ -48,6 +48,11 @@ class AccessibleCalendarsTest extends TestCase
             "http_client" => $http,
         ));
 
-        $cronofy->list_accessible_calendars($profileId);
+        $accesibleCalendars = $cronofy->list_accessible_calendars($profileId);
+
+        $this->assertEquals(
+            json_decode($accessible_calendars_response, true),
+            $accesibleCalendars
+        );
     }
 }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -18,6 +18,23 @@ class CronofyTest extends TestCase
             . "&redirect_uri=http%3A%2F%2Fyoursite.dev%2Foauth2%2Fcallback&scope=read_account%20list_calendars", $auth);
     }
 
+    public function testDelegatedScopeInAuthorizationUrl()
+    {
+        $redirect_uri = "http://yoursite.dev/oauth2/callback";
+
+        $cronofy = new Cronofy(array("client_id" => "clientId"));
+        $params = array(
+            'redirect_uri' => $redirect_uri,
+            'scope' => array('read_account','list_calendars'),
+            'delegated_scope' => array('create_calendar', 'read_free_busy')
+        );
+        $auth = $cronofy->getAuthorizationURL($params);
+
+        $this->assertEquals("https://app.cronofy.com/oauth/authorize?response_type=code&client_id=clientId"
+            . "&redirect_uri=http%3A%2F%2Fyoursite.dev%2Foauth2%2Fcallback"
+            . "&scope=read_account%20list_calendars&delegated_scope=create_calendar%20read_free_busy", $auth);
+    }
+
     public function testErrorHandling()
     {
         $args = array(


### PR DESCRIPTION
This PR introduces two changes:
- `getAuthorizationUrl` allows to pass a `delegated_scope` query string param (optional for Individual Connect, but required to make use of Business Connect).
- Adds the `list_accessible_calendars` method.