### PR TITLE
Added check for recipient and recipients in smart invite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.phar
+.idea

--- a/cronofy.php
+++ b/cronofy.php
@@ -946,7 +946,6 @@ class Cronofy
          */
 
         $postfields = array(
-          "recipient" => $params["recipient"],
           "event" => $params["event"],
           "smart_invite_id" => $params["smart_invite_id"],
           "callback_url" => $params["callback_url"],
@@ -954,6 +953,12 @@ class Cronofy
 
         if (!empty($params['organizer'])) {
             $postfields['organizer'] = $params['organizer'];
+        }
+
+        if(!empty($params['recipients'])) {
+            $postfields['recipients'] = $params['recipients'];
+        } else {
+            $postfields['recipient'] = $params['recipient'];
         }
 
         return $this->api_key_http_post("/" . self::API_VERSION . "/smart_invites", $postfields);

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -341,4 +341,52 @@ class CronofyTest extends TestCase
         $actual = $cronofy->create_smart_invite($params);
         $this->assertNotNull($actual);
     }
+
+    public function testCreateSmartInviteWithMultipleRecipients()
+    {
+        $event = array(
+            "summary" => "Add to Calendar test event",
+            "start" => "2017-01-01T12:00:00Z",
+            "end" => "2017-01-01T15:00:00Z"
+        );
+        $organizer = array("name" => "Smart invite application");
+        $smart_invite_id = "foo";
+        $callback_url = "http://www.example.com/callback";
+
+        $params = array(
+            "recipients" => array(
+                array("email" => "example@example.com"),
+                array("email" => "example@example.org"),
+            ),
+            "event" => $event,
+            "smart_invite_id" => $smart_invite_id,
+            "callback_url" => $callback_url,
+            "organizer" => $organizer,
+        );
+
+        $http = $this->createMock('HttpRequest');
+        $http->expects($this->once())
+            ->method('http_post')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/smart_invites'),
+                $this->equalTo($params),
+                $this->equalTo(array(
+                    'Authorization: Bearer clientSecret',
+                    'Host: api.cronofy.com',
+                    'Content-Type: application/json; charset=utf-8'
+                ))
+            )
+            ->will($this->returnValue(array("{'foo': 'bar'}", 200)));
+
+        $cronofy = new Cronofy(array(
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ));
+
+        $actual = $cronofy->create_smart_invite($params);
+        $this->assertNotNull($actual);
+    }
 }


### PR DESCRIPTION
Currently cronofy php library doesn't support "recipients" for creating smart invites so I extended this functionality.