### PR TITLE
Add boolean branch for param encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.3]
+
+* allow serialization of booleans in params
+
 ## [1.1.2]
 
 * disable libcurl verbose output
@@ -27,6 +31,8 @@
 [1.0.1]: https://github.com/cronofy/cronofy-php/releases/tag/v1.0.1
 [1.1.0]: https://github.com/cronofy/cronofy-php/releases/tag/v1.1.0
 [1.1.1]: https://github.com/cronofy/cronofy-php/releases/tag/v1.1.1
+[1.1.2]: https://github.com/cronofy/cronofy-php/releases/tag/v1.1.2
+[1.1.3]: https://github.com/cronofy/cronofy-php/releases/tag/v1.1.3
 
 [#32]: https://github.com/cronofy/cronofy-php/pull/76
 [#33]: https://github.com/cronofy/cronofy-php/pull/74

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "cronofy/cronofy",
     "description": "PHP wrapper for Cronofy's unified calendar API",
-    "version": "v1.1.2",
+    "version": "v1.1.3",
     "require": {
         "php": "^7.1"
     },

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -992,6 +992,9 @@ class Cronofy
                 for ($i = 0; $i < count($val); $i++) {
                     array_push($str_params, $key . "[]=" . urlencode($val[$i]));
                 }
+            } elseif (gettype($val) == "boolean") {
+                $bool_str = $val ? "true" : "false";
+                array_push($str_params, $key . "=" . urlencode($bool_str));
             } else {
                 array_push($str_params, $key . "=" . urlencode($val));
             }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -249,6 +249,35 @@ class CronofyTest extends TestCase
         $this->assertNotNull($actual);
     }
 
+    public function testFreeBusy()
+    {
+        $http = $this->createMock(HttpRequest::class);
+        $http->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/free_busy?localized_times=true'),
+                $this->equalTo([
+                    'Authorization: Bearer accessToken',
+                    'Host: api.cronofy.com'
+                ])
+            )
+            ->will($this->returnValue(["{'foo': 'bar'}", 200]));
+
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ]);
+
+        $params = [
+          "localized_times" => true
+        ];
+        $actual = $cronofy->freeBusy($params);
+        $this->assertNotNull($actual);
+    }
+
     public function testGetSmartInvite()
     {
         $http = $this->createMock(HttpRequest::class);

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -251,17 +251,32 @@ class CronofyTest extends TestCase
 
     public function testFreeBusy()
     {
+        $page_1 = '{
+          "pages": {
+            "current": 1,
+            "total": 1,
+          },
+          "events": [
+            {
+              "calendar_id": "cal_U9uuErStTG@EAAAB_IsAsykA2DBTWqQTf-f0kJw",
+              "event_uid": "evt_external_event_one",
+              "summary": "Company Retreat"
+            }
+          ]
+        }';
+
         $http = $this->createMock(HttpRequest::class);
-        $http->expects($this->once())
-            ->method('httpGet')
+        $http->expects($this->at(0))
+            ->method('getPage')
             ->with(
-                $this->equalTo('https://api.cronofy.com/v1/free_busy?localized_times=true'),
+                $this->equalTo('https://api.cronofy.com/v1/free_busy'),
                 $this->equalTo([
                     'Authorization: Bearer accessToken',
                     'Host: api.cronofy.com'
-                ])
+                ]),
+                "?localized_times=true"
             )
-            ->will($this->returnValue(["{'foo': 'bar'}", 200]));
+            ->will($this->returnValue([$page_1, 200]));
 
         $cronofy = new Cronofy([
             "client_id" => "clientId",
@@ -271,9 +286,7 @@ class CronofyTest extends TestCase
             "http_client" => $http,
         ]);
 
-        $params = [
-          "localized_times" => true
-        ];
+        $params = [ "localized_times" => true ];
         $actual = $cronofy->freeBusy($params);
         $this->assertNotNull($actual);
     }


### PR DESCRIPTION
https://cronofy.zendesk.com/agent/tickets/13924

Allow boolean params to be marshaled to URL encoded strings