### PR TITLE
Add method for requesting an element token for use with UI elements

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -192,6 +192,30 @@ class Cronofy
         return $url;
     }
 
+    public function requestElementToken($params)
+    {
+        /*
+          Array $params : An array of additional parameters
+          permissions : Array. An array of permissions the token will be granted. REQUIRED
+          subs:  : Array. An array of subs to identify the accounts the token is allowed to access  REQUIRED
+          origin: String he Origin of the application where the Element will be used. REQUIRED
+
+          Response Array:
+          element_token.permissions : The array of permissions granted.
+          element_token.origin : The permitted Origin the token can be used with.
+          element_token.token : The token that is passed to Elements to authenticate them.
+          element_token.expires_in : The number of seconds the token can be used for.
+         */
+        $postfields = [
+            "version" => "1",
+            "permissions" => $params['permissions'],
+            'subs' => $params['subs'],
+            "origin" => $params['origin']
+        ];
+
+        return $this->apiKeyHttpPost("/v1/element_tokens", $postfields);
+    }
+
     public function requestToken($params)
     {
         /*

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -497,4 +497,50 @@ class CronofyTest extends TestCase
         $actual = $cronofy->createSmartInvite($params);
         $this->assertNotNull($actual);
     }
+
+    public function testRequestElementToken()
+    {
+        $params = [
+            "version" => "1",
+            "permissions" => ["agenda", "availability"],
+            'subs' => ['acc_12345678'],
+            "origin" => 'http://local.test'
+        ];
+
+        $response = [
+            "element_token" =>  [
+                "permissions" => ["agenda", "availability"],
+                "origin" => 'http://local.test',
+                "token" => "ELEMENT_TOKEN",
+                "expires_in" => 64800
+            ]
+        ];
+
+        $http = $this->createMock(HttpRequest::class);
+        $http->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/element_tokens'),
+                $this->equalTo($params),
+                $this->equalTo([
+                    'Authorization: Bearer clientSecret',
+                    'Host: api.cronofy.com',
+                    'Content-Type: application/json; charset=utf-8'
+                ])
+            )
+            ->will($this->returnValue([json_encode($response), 200]))
+        ;
+
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ]);
+
+        $actual = $cronofy->requestElementToken($params);
+        $this->assertNotNull($actual);
+    }
+
 }


### PR DESCRIPTION
This PR adds a new method for the requesting of element tokens to make the [/v1/element_tokens](https://docs.cronofy.com/developers/ui-elements/authentication/) endpoint available through this library. I've tried to follow the established pattern for how your code is written but any of this can be adjusted if need be.