### PR TITLE
Pass all conferencing params when upserting an event

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -537,9 +537,7 @@ class Cronofy
             $postFields['attendees'] = $params['attendees'];
         }
         if (!empty($params['conferencing'])) {
-            if (!empty($params['conferencing']['profile_id'])) {
-                $postFields['conferencing'] = ['profile_id' => $params['conferencing']['profile_id']];
-            }
+            $postFields['conferencing'] = $params['conferencing'];
         }
 
         return $this->httpPost("/" . self::API_VERSION . "/calendars/" . $params['calendar_id'] . "/events", $postFields);


### PR DESCRIPTION
When upserting an event, the API supports passing additional parameters for conferencing solutions:

```
  "conferencing": {
    "profile_id": "explicit",
    "provider_description": "Custom conferencing",
    "join_url": "https://conferencing.example.com/join/xyz"
  }
```

However, the current PHP SDK only passes the `profile_id`. Cronofy has been updated to allow passing arbitrary provider description and join_url properties, and this allows those to be set from the SDK.