### PR TITLE
Support revoking subs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.7]
+
+* support revoking subs
+
 ## [1.1.6]
 
 * less restrictive options for `conferencing`

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "cronofy/cronofy",
     "description": "PHP wrapper for Cronofy's unified calendar API",
-    "version": "v1.1.6",
+    "version": "v1.1.7",
     "require": {
         "php": "^7.1"
     },

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -300,10 +300,12 @@ class Cronofy
         }
     }
 
-    public function revokeAuthorization($token)
+    public function revokeAuthorization($params)
     {
         /*
-          String token : Either the refresh_token or access_token for the authorization you wish to revoke. REQUIRED
+          Array $params : An array of additional parameters
+          String token : Either the refresh_token or access_token for the authorization you wish to revoke. OPTIONAL
+          String sub : The sub value for the account you wish to revoke. OPTIONAL
 
           Response :
           true if successful, error string if not
@@ -311,8 +313,20 @@ class Cronofy
         $postfields = [
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
-            'token' => $token
         ];
+
+        if (is_string($params)) {
+            // in version <= 1.1.6 the method only supported token
+            $params = ['token' => $params];
+        }
+
+        if (array_key_exists('token', $params)) {
+            $postfields['token'] = $params['token'];
+        }
+
+        if (array_key_exists('sub', $params)) {
+            $postfields['sub'] = $params['sub'];
+        }
 
         return $this->httpPost("/oauth/token/revoke", $postfields);
     }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -189,7 +189,7 @@ class CronofyTest extends TestCase
         $http->expects($this->once())
             ->method('httpPost')
             ->with(
-                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
                     'Host: api.cronofy.com'
                 ]),
@@ -221,7 +221,7 @@ class CronofyTest extends TestCase
         $http->expects($this->once())
             ->method('httpPost')
             ->with(
-                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
                     'Host: api.cronofy.com'
                 ]),
@@ -253,7 +253,7 @@ class CronofyTest extends TestCase
         $http->expects($this->once())
             ->method('httpPost')
             ->with(
-                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
                     'Host: api.cronofy.com'
                 ]),

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -183,6 +183,100 @@ class CronofyTest extends TestCase
         $this->assertNotNull($actual);
     }
 
+    public function testRevokeAuthorizationWithString()
+    {
+        $http = $this->createMock(HttpRequest::class);
+        $http->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo([
+                    'Host: api.cronofy.com'
+                ]),
+                $this->equalTo([
+                    'client_id' => 'clientId',
+                    'client_secret' => 'clientSecret',
+                    'token' => 'sometoken'
+                ])
+            )
+            ->will($this->returnValue(["{'foo': 'bar'}", 200]));
+
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ]);
+
+        $actual = $cronofy->revokeAuthorization('sometoken');
+        $this->assertNotNull($actual);
+    }
+
+
+
+    public function testRevokeAuthorizationWithToken()
+    {
+        $http = $this->createMock(HttpRequest::class);
+        $http->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo([
+                    'Host: api.cronofy.com'
+                ]),
+                $this->equalTo([
+                    'client_id' => 'clientId',
+                    'client_secret' => 'clientSecret',
+                    'token' => 'sometoken'
+                ])
+            )
+            ->will($this->returnValue(["{'foo': 'bar'}", 200]));
+
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ]);
+
+        $actual = $cronofy->revokeAuthorization(['token' => 'sometoken']);
+        $this->assertNotNull($actual);
+    }
+
+
+
+    public function testRevokeAuthorizationWithSub()
+    {
+        $http = $this->createMock(HttpRequest::class);
+        $http->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/oauth/token/revoke'),
+                $this->equalTo([
+                    'Host: api.cronofy.com'
+                ]),
+                $this->equalTo([
+                    'client_id' => 'clientId',
+                    'client_secret' => 'clientSecret',
+                    'sub' => 'somesub'
+                ])
+            )
+            ->will($this->returnValue(["{'foo': 'bar'}", 200]));
+
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => $http,
+        ]);
+
+        $actual = $cronofy->revokeAuthorization(['sub' => 'somesub']);
+        $this->assertNotNull($actual);
+    }
+
     public function testDeleteEvent()
     {
         $params = ["event_id" => "evt_456"];

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -191,12 +191,13 @@ class CronofyTest extends TestCase
             ->with(
                 $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
-                    'Host: api.cronofy.com'
-                ]),
-                $this->equalTo([
                     'client_id' => 'clientId',
                     'client_secret' => 'clientSecret',
                     'token' => 'sometoken'
+                ]),
+                $this->equalTo([
+                    'Host: api.cronofy.com',
+                    'Content-Type: application/json; charset=utf-8'
                 ])
             )
             ->will($this->returnValue(["{'foo': 'bar'}", 200]));
@@ -204,8 +205,6 @@ class CronofyTest extends TestCase
         $cronofy = new Cronofy([
             "client_id" => "clientId",
             "client_secret" => "clientSecret",
-            "access_token" => "accessToken",
-            "refresh_token" => "refreshToken",
             "http_client" => $http,
         ]);
 
@@ -223,12 +222,13 @@ class CronofyTest extends TestCase
             ->with(
                 $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
-                    'Host: api.cronofy.com'
-                ]),
-                $this->equalTo([
                     'client_id' => 'clientId',
                     'client_secret' => 'clientSecret',
                     'token' => 'sometoken'
+                ]),
+                $this->equalTo([
+                    'Host: api.cronofy.com',
+                    'Content-Type: application/json; charset=utf-8'
                 ])
             )
             ->will($this->returnValue(["{'foo': 'bar'}", 200]));
@@ -236,8 +236,6 @@ class CronofyTest extends TestCase
         $cronofy = new Cronofy([
             "client_id" => "clientId",
             "client_secret" => "clientSecret",
-            "access_token" => "accessToken",
-            "refresh_token" => "refreshToken",
             "http_client" => $http,
         ]);
 
@@ -255,12 +253,13 @@ class CronofyTest extends TestCase
             ->with(
                 $this->equalTo('https://api.cronofy.com/oauth/token/revoke'),
                 $this->equalTo([
-                    'Host: api.cronofy.com'
-                ]),
-                $this->equalTo([
                     'client_id' => 'clientId',
                     'client_secret' => 'clientSecret',
                     'sub' => 'somesub'
+                ]),
+                $this->equalTo([
+                    'Host: api.cronofy.com',
+                    'Content-Type: application/json; charset=utf-8'
                 ])
             )
             ->will($this->returnValue(["{'foo': 'bar'}", 200]));
@@ -268,8 +267,6 @@ class CronofyTest extends TestCase
         $cronofy = new Cronofy([
             "client_id" => "clientId",
             "client_secret" => "clientSecret",
-            "access_token" => "accessToken",
-            "refresh_token" => "refreshToken",
             "http_client" => $http,
         ]);
 


### PR DESCRIPTION
The https://docs.cronofy.com/developers/api/authorization/revoke/ endpoint accepts either a token or a sub, This PR adds the ability to revoke a sub or a token.

Fallback to token if only string is supported to not have a BC break