### PR TITLE
add "provider_name" param to conferencingServiceAuthorization

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1020,6 +1020,10 @@ class Cronofy
         $postFields = [
             'redirect_uri' => $params['redirect_uri'],
         ];
+        
+        if (!empty($params['provider_name'])) {
+            $postFields['provider_name'] = $params['provider_name'];
+        }
 
         return $this->httpPost("/" . self::API_VERSION . "/conferencing_service_authorizations", $postFields);
     }


### PR DESCRIPTION
Add "provider_name" param to `\Cronofy\Cronofy::conferencingServiceAuthorization` to managed the newly added param : 
https://docs.cronofy.com/developers/api/conferencing-services/authorization/#param-provider_name