### PR TITLE
Add batch endpoint support

### DIFF
--- a/src/Batch/Batch.php
+++ b/src/Batch/Batch.php
@@ -4,7 +4,7 @@ namespace Cronofy\Batch;
 
 use Cronofy\Cronofy;
 
-class BatchBuilder
+class Batch
 {
     /** @var BatchRequest[] */
     private $requests = [];

--- a/src/Batch/BatchBuilder.php
+++ b/src/Batch/BatchBuilder.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Batch;
+
+use Cronofy\Cronofy;
+
+class BatchBuilder
+{
+    /** @var BatchRequest[] */
+    private $requests = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function upsertEvent(string $calendarId, array $data): self
+    {
+        $path = $this->buildEventsPath($calendarId);
+
+        return $this->addPostRequest($path, $data);
+    }
+
+    public function deleteEvent(string $calendarId, string $eventId): self
+    {
+        $path = $this->buildEventsPath($calendarId);
+        $data = ['event_id' => $eventId];
+
+        return $this->addDeleteRequest($path, $data);
+    }
+
+    public function updateExternalEvent(string $calendarId, array $data): self
+    {
+        $path = $this->buildEventsPath($calendarId);
+
+        return $this->addPostRequest($path, $data);
+    }
+
+    public function deleteExternalEvent(string $calendarId, string $eventUid): self
+    {
+        $path = $this->buildEventsPath($calendarId);
+        $data = ['event_uid' => $eventUid];
+
+        return $this->addDeleteRequest($path, $data);
+    }
+
+    public function upsertAvailablePeriod(array $data): self
+    {
+        $path = $this->buildAvailablePeriodsPath();
+
+        return $this->addPostRequest($path, $data);
+    }
+
+    public function deleteAvailablePeriod(string $availablePeriodId): self
+    {
+        $path = $this->buildAvailablePeriodsPath();
+        $data = ['available_period_id' => $availablePeriodId];
+
+        return $this->addDeleteRequest($path, $data);
+    }
+
+    private function buildEventsPath(string $calendarId): string
+    {
+        return sprintf('/%s/calendars/%s/events', Cronofy::API_VERSION, $calendarId);
+    }
+
+    private function buildAvailablePeriodsPath(): string
+    {
+        return sprintf('/%s/available_periods', Cronofy::API_VERSION);
+    }
+
+    private function addPostRequest(string $relativeUrl, array $data): self
+    {
+        return $this->addRequest('POST', $relativeUrl, $data);
+    }
+
+    private function addDeleteRequest(string $relativeUrl, array $data): self
+    {
+        return $this->addRequest('DELETE', $relativeUrl, $data);
+    }
+
+    private function addRequest(string $method, string $relativeUrl, array $data): self
+    {
+        $this->requests[] = new BatchRequest($method, $relativeUrl, $data);
+
+        return $this;
+    }
+
+    public function requests(): array
+    {
+        return $this->requests;
+    }
+}

--- a/src/Batch/BatchRequest.php
+++ b/src/Batch/BatchRequest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Batch;
+
+class BatchRequest
+{
+    private $method;
+    private $relativeUrl;
+    private $data;
+
+    public function __construct(string $method, string $relativeUrl, array $data)
+    {
+        $this->method = $method;
+        $this->relativeUrl = $relativeUrl;
+        $this->data = $data;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    public function relativeUrl(): string
+    {
+        return $this->relativeUrl;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Batch/BatchResponse.php
+++ b/src/Batch/BatchResponse.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Batch;
+
+class BatchResponse
+{
+    private $status;
+    private $headers;
+    private $data;
+    private $request;
+
+    public function __construct(int $status, ?array $headers, ?array $data, BatchRequest $request)
+    {
+        $this->status = $status;
+        $this->headers = $headers;
+        $this->data = $data;
+        $this->request = $request;
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
+    public function hasSuccessStatus(): bool
+    {
+        $status = $this->status();
+
+        return $status >= 200 && $status < 300;
+    }
+
+    public function hasErrorStatus(): bool
+    {
+        return !$this->hasSuccessStatus();
+    }
+
+    public function headers(): ?array
+    {
+        return $this->headers;
+    }
+
+    public function data(): ?array
+    {
+        return $this->data;
+    }
+
+    public function request(): BatchRequest
+    {
+        return $this->request;
+    }
+}

--- a/src/Batch/BatchResult.php
+++ b/src/Batch/BatchResult.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Batch;
+
+class BatchResult
+{
+    private $responses;
+    private $errors;
+
+    public function __construct(BatchResponse ...$responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function responses(): array
+    {
+        return $this->responses;
+    }
+
+    public function errors(): array
+    {
+        if ($this->errors === null) {
+            $this->errors = [];
+
+            foreach ($this->responses as $response) {
+                if ($response->hasErrorStatus()) {
+                    $this->errors[] = $response;
+                }
+            }
+        }
+
+        return $this->errors;
+    }
+
+    public function hasErrors(): bool
+    {
+        return count($this->errors()) > 0;
+    }
+}

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -6,7 +6,7 @@ use Cronofy\Batch\BatchRequest;
 use Cronofy\Exception\CronofyException;
 use Cronofy\Exception\PartialBatchFailureException;
 use Cronofy\Http\CurlRequest;
-use Cronofy\Batch\BatchBuilder;
+use Cronofy\Batch\Batch;
 use Cronofy\Batch\BatchResponse;
 use Cronofy\Batch\BatchResult;
 
@@ -1033,7 +1033,7 @@ class Cronofy
         return $this->httpPost("/" . self::API_VERSION . "/conferencing_service_authorizations", $postFields);
     }
 
-    public function batch(BatchBuilder $batch): BatchResult
+    public function executeBatch(Batch $batch): BatchResult
     {
         $requests = $batch->requests();
 

--- a/src/Exception/PartialBatchFailureException.php
+++ b/src/Exception/PartialBatchFailureException.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Exception;
+
+use Cronofy\Batch\BatchResult;
+use Exception;
+
+class PartialBatchFailureException extends Exception
+{
+    private $result;
+
+    public function __construct(string $message, BatchResult $result)
+    {
+        $this->result = $result;
+
+        parent::__construct($message);
+    }
+
+    public function result(): BatchResult
+    {
+        return $this->result;
+    }
+}

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -1,0 +1,498 @@
+<?php declare(strict_types=1);
+
+namespace Cronofy\Tests;
+
+use Cronofy\Batch\BatchBuilder;
+use Cronofy\Batch\BatchRequest;
+use Cronofy\Batch\BatchResponse;
+use Cronofy\Batch\BatchResult;
+use Cronofy\Cronofy;
+use Cronofy\Exception\PartialBatchFailureException;
+use Cronofy\Http\HttpRequest;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class BatchTest extends TestCase
+{
+    /** @var HttpRequest|PHPUnit_Framework_MockObject_MockObject */
+    private $httpClient;
+
+    /** @var Cronofy */
+    private $cronofy;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->httpClient = $this->createMock(HttpRequest::class);
+
+        $this->cronofy = new Cronofy([
+            'client_id' => 'clientId',
+            'client_secret' => 'clientSecret',
+            'access_token' => 'accessToken',
+            'refresh_token' => 'refreshToken',
+            'http_client' => $this->httpClient,
+        ]);
+    }
+
+    public function testUpsertEvent()
+    {
+        $calendarId = 'calendar_id';
+        $data = $this->getUpsertEventData();
+
+        $expectedRequestMethod = 'POST';
+        $expectedRequestRelativeUrl = sprintf('/v1/calendars/%s/events', $calendarId);
+        $expectedRequestData = $data;
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 202;
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->upsertEvent($calendarId, $data);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertNull($response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testUpdateExternalEvent()
+    {
+        $calendarId = 'calendar_id';
+        $data = $this->getUpdateExternalEventData();
+
+        $expectedRequestMethod = 'POST';
+        $expectedRequestRelativeUrl = sprintf('/v1/calendars/%s/events', $calendarId);
+        $expectedRequestData = $data;
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 202;
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->updateExternalEvent($calendarId, $data);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertNull($response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testDeleteEvent()
+    {
+        $calendarId = 'calendar_id';
+        $eventId = 'event_id';
+
+        $expectedRequestMethod = 'DELETE';
+        $expectedRequestRelativeUrl = sprintf('/v1/calendars/%s/events', $calendarId);
+        $expectedRequestData = [
+            'event_id' => $eventId,
+        ];
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 204;
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->deleteEvent($calendarId, $eventId);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertNull($response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testDeleteExternalEvent()
+    {
+        $calendarId = 'calendar_id';
+        $externalEventId = 'external_event_id';
+
+        $expectedRequestMethod = 'DELETE';
+        $expectedRequestRelativeUrl = sprintf('/v1/calendars/%s/events', $calendarId);
+        $expectedRequestData = [
+            'event_uid' => $externalEventId,
+        ];
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 204;
+        $expectedResponseHeaders = [
+            'Header' => 'Value',
+        ];
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+                'headers' => $expectedResponseHeaders,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->deleteExternalEvent($calendarId, $externalEventId);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertEquals($expectedResponseHeaders, $response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testUpsertAvailablePeriod()
+    {
+        $data = $this->getUpsertAvailablePeriodData();
+
+        $expectedRequestMethod = 'POST';
+        $expectedRequestRelativeUrl = '/v1/available_periods';
+        $expectedRequestData = $data;
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 202;
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->upsertAvailablePeriod($data);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertNull($response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testDeleteAvailablePeriod()
+    {
+        $availablePeriodId = 'available_period_id';
+
+        $expectedRequestMethod = 'DELETE';
+        $expectedRequestRelativeUrl = '/v1/available_periods';
+        $expectedRequestData = [
+            'available_period_id' => $availablePeriodId,
+        ];
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 204;
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->deleteAvailablePeriod($availablePeriodId);
+        $result = $this->cronofy->batch($batch);
+
+        $this->assertInstanceOf(BatchResult::class, $result);
+
+        $responses = $result->responses();
+
+        $this->assertCount(1, $responses);
+
+        $response = $responses[0];
+
+        $this->assertEquals($expectedResponseStatus, $response->status());
+        $this->assertNull($response->headers());
+        $this->assertNull($response->data());
+
+        $request = $response->request();
+
+        $this->assertInstanceOf(BatchRequest::class, $request);
+        $this->assertEquals($expectedRequestMethod, $request->method());
+        $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+        $this->assertEquals($expectedRequestData, $request->data());
+    }
+
+    public function testPartialBatchFailure()
+    {
+        $data = $this->getUpsertAvailablePeriodData();
+        unset($data['start']);
+
+        $expectedRequestMethod = 'POST';
+        $expectedRequestRelativeUrl = '/v1/available_periods';
+        $expectedRequestData = $data;
+
+        $expectedRequests = [
+            [
+                'method' => $expectedRequestMethod,
+                'relative_url' => $expectedRequestRelativeUrl,
+                'data' => $expectedRequestData,
+            ],
+        ];
+
+        $expectedResponseStatus = 422;
+        $expectedResponseData = [
+            'errors' => [
+                'start' => [
+                    [
+                        'key' => 'errors.required',
+                        'description' => 'start must be specified',
+                    ],
+                ],
+            ],
+        ];
+
+        $mockResponses = [
+            [
+                'status' => $expectedResponseStatus,
+                'data' => $expectedResponseData,
+            ],
+        ];
+
+        $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
+
+        $batch = BatchBuilder::create()->upsertAvailablePeriod($data);
+
+        try {
+            $this->cronofy->batch($batch);
+        } catch (PartialBatchFailureException $exception) {
+            $result = $exception->result();
+
+            $this->assertInstanceOf(BatchResult::class, $result);
+            $this->assertTrue($result->hasErrors());
+
+            $errors = $result->errors();
+
+            $this->assertCount(1, $errors);
+
+            $error = $errors[0];
+
+            $this->assertInstanceOf(BatchResponse::class, $error);
+            $this->assertEquals($expectedResponseStatus, $error->status());
+            $this->assertNull($error->headers());
+            $this->assertEquals($expectedResponseData, $error->data());
+
+            $request = $error->request();
+
+            $this->assertInstanceOf(BatchRequest::class, $request);
+            $this->assertEquals($expectedRequestMethod, $request->method());
+            $this->assertEquals($expectedRequestRelativeUrl, $request->relativeUrl());
+            $this->assertEquals($expectedRequestData, $request->data());
+
+            return;
+        }
+
+        $this->fail(sprintf('Expected exception of type "%s" to be thrown.', PartialBatchFailureException::class));
+    }
+
+    private function makeBatchRequestExpectation(array $requests, array $responses): void
+    {
+        $this->httpClient
+            ->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                $this->equalTo('https://api.cronofy.com/v1/batch'),
+                $this->equalTo([
+                    'batch' => $requests,
+                ])
+            )
+            ->will(
+                $this->returnValue([
+                    json_encode([
+                        'batch' => $responses,
+                    ]),
+                    207,
+                ])
+            );
+    }
+
+    private function getUpsertEventData(): array
+    {
+        return array_merge(
+            ['event_id' => 'event_id'],
+            $this->getBaseEventData()
+        );
+    }
+
+    private function getUpdateExternalEventData(): array
+    {
+        return array_merge(
+            ['event_uid' => 'external_event_id'],
+            $this->getBaseEventData()
+        );
+    }
+
+    private function getBaseEventData(): array
+    {
+        return [
+            'summary' => 'Upsert Event Test',
+            'description' => 'description example',
+            'start' => '2017-01-01T12:00:00Z',
+            'end' => '2017-01-01T15:00:00Z',
+            'tzid' => 'Europe/London',
+            'location' => [
+                'description' => 'board room',
+                'latitude' => '12.2344',
+                'longitude' => '45.2444',
+            ],
+            'reminders' => [
+                ['minutes' => 30],
+                ['minutes' => 1440],
+            ],
+            'attendees' => [
+                'invite' => [
+                    ['email' => 'new_invitee@test.com', 'display_name' => 'New Invitee'],
+                ],
+                'reject' => [
+                    ['email' => 'old_invitee@test.com', 'display_name' => 'Old Invitee'],
+                ],
+            ],
+            'event_private' => true,
+            'reminders_create_only' => true,
+            'transparency' => 'opaque',
+            'color' => '#c6040f',
+            'conferencing' => [
+                'profile_id' => 'default',
+            ],
+        ];
+    }
+
+    private function getUpsertAvailablePeriodData(): array
+    {
+        return [
+            'available_period_id' => 'available_period_id',
+            'start' => '2021-04-14T15:30:00Z',
+            'end' => '2021-04-14T17:00:00Z',
+        ];
+    }
+}

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -2,7 +2,7 @@
 
 namespace Cronofy\Tests;
 
-use Cronofy\Batch\BatchBuilder;
+use Cronofy\Batch\Batch;
 use Cronofy\Batch\BatchRequest;
 use Cronofy\Batch\BatchResponse;
 use Cronofy\Batch\BatchResult;
@@ -62,8 +62,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->upsertEvent($calendarId, $data);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->upsertEvent($calendarId, $data);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -112,8 +112,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->updateExternalEvent($calendarId, $data);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->updateExternalEvent($calendarId, $data);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -164,8 +164,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->deleteEvent($calendarId, $eventId);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->deleteEvent($calendarId, $eventId);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -220,8 +220,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->deleteExternalEvent($calendarId, $externalEventId);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->deleteExternalEvent($calendarId, $externalEventId);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -269,8 +269,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->upsertAvailablePeriod($data);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->upsertAvailablePeriod($data);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -320,8 +320,8 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->deleteAvailablePeriod($availablePeriodId);
-        $result = $this->cronofy->batch($batch);
+        $batch = Batch::create()->deleteAvailablePeriod($availablePeriodId);
+        $result = $this->cronofy->executeBatch($batch);
 
         $this->assertInstanceOf(BatchResult::class, $result);
 
@@ -381,10 +381,10 @@ class BatchTest extends TestCase
 
         $this->makeBatchRequestExpectation($expectedRequests, $mockResponses);
 
-        $batch = BatchBuilder::create()->upsertAvailablePeriod($data);
+        $batch = Batch::create()->upsertAvailablePeriod($data);
 
         try {
-            $this->cronofy->batch($batch);
+            $this->cronofy->executeBatch($batch);
         } catch (PartialBatchFailureException $exception) {
             $result = $exception->result();
 

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -20,7 +20,7 @@ class BatchTest extends TestCase
     /** @var Cronofy */
     private $cronofy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Hi Guys,

I've written a partial port of the batch implementation in your Ruby / C# clients. Example usage:

```php
use Cronofy\Batch\Batch;
use Cronofy\Cronofy;
use Cronofy\Exception\PartialBatchFailureException;

$cronofy = new Cronofy([
    // ...
]);

$batch = Batch::create()
    ->deleteEvent($calendarId, $eventId)
    ->upsertEvent($calendarId, $data)
    // etc...
    ->deleteAvailablePeriod($availablePeriodId);

try {
    $result = $cronofy->executeBatch($batch);

    foreach ($result->responses() as $response) {
        // $response->status();
        // $response->headers();
        // $response->data();
        // $response->request();
    }
} catch (PartialBatchFailureException $exception) {
    $result = $exception->result();

    foreach ($result->errors() as $response) {
        // $response->status();
        // $response->headers();
        // $response->data();
        // $response->request();
    }
}
```

Let me know if there's anymore more you need from me to get this merged. Closes #95

Cheers,
Jack

