### PR TITLE
allow empty string in request parameter "description"

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -528,7 +528,7 @@ class Cronofy
 
     private function baseUpsertEvent($postFields, $params)
     {
-        if (!empty($params['description'])) {
+        if (isset($params['description'])) {
             $postFields['description'] = $params['description'];
         }
         if (!empty($params['tzid'])) {


### PR DESCRIPTION
In the [documentation for the endpoint "calendars/{calendar_id}/events"](https://docs.cronofy.com/developers/api/events/upsert-event/#param-description) for the request parameter "description", its says: 

> To clear a description, set it to an empty string "".

To be able to do that, the condition should be `if (isset($params['description']))` and not `if (!empty($params['description']))`