### PR TITLE
Allow param "subscriptions" in \Cronofy::baseUpsertEvent

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -558,6 +558,9 @@ class Cronofy
         if (!empty($params['conferencing'])) {
             $postFields['conferencing'] = $params['conferencing'];
         }
+        if (!empty($params['subscriptions'])) {
+            $postFields['subscriptions'] = $params['subscriptions'];
+        }
 
         return $this->httpPost("/" . self::API_VERSION . "/calendars/" . $params['calendar_id'] . "/events", $postFields);
     }


### PR DESCRIPTION
In the [documentation for Conferencing Services Push Notifications](https://docs.cronofy.com/developers/api/conferencing-services/subscriptions/#param-subscriptions) a new "subscriptions" parameter is mentioned for the calendars/{calendar_id}/events" endpoint.
This PR allows this parameter.