### PR TITLE
HMAC validation added

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1140,7 +1140,7 @@ class Cronofy
         return $result;
     }
 
-    public function verifyHMAC($hmac_header, $body)
+    public function hmacValid($hmac_header, $body)
     {
         if ($hmac_header == null  || empty($hmac_header)) {
             return false;

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1143,15 +1143,15 @@ class Cronofy
     public function hmacValid($hmac_header, $body)
     {
         /* Verifies a HMAC from a push notification using the client secret.
-        
-          String hmac_header: A String containing comma-separated values 
-          describing HMACs of the notification taken from the Cronofy-HMAC-SHA256 header.
 
-          String body: A String of the body of the notification.
+        String hmac_header: A String containing comma-separated values
+        describing HMACs of the notification taken from the Cronofy-HMAC-SHA256 header.
 
-          Returns true if one of the HMAC provided matches the one calculated using the
-          client secret, otherwise false.
-         */
+        String body: A String of the body of the notification.
+
+        Returns true if one of the HMAC provided matches the one calculated using the
+        client secret, otherwise false.
+        */
 
         if ($hmac_header == null  || empty($hmac_header)) {
             return false;

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1140,15 +1140,15 @@ class Cronofy
         return $result;
     }
 
-    public function hmacMatch($params, $body)
+    public function verifyHMAC($hmac_header, $body)
     {
-        if ($params['hmac'] == null  || empty($params['hmac'])) {
+        if ($hmac_header == null  || empty($hmac_header)) {
             return false;
         }
 
         $digest = hash_hmac('sha256', $body, $this->clientSecret);
         $calculated = base64_encode($digest);
-        $hmac_list = explode(',', $params['hmac']);
+        $hmac_list = explode(',', $hmac_header);
 
         return in_array($calculated, $hmac_list);
     }

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1140,6 +1140,19 @@ class Cronofy
         return $result;
     }
 
+    public function hmacMatch($params, $body)
+    {
+        if ($params['hmac'] == null  || empty($params['hmac'])) {
+            return false;
+        }
+
+        $digest = hash_hmac('sha256', $body, $this->clientSecret);
+        $calculated = base64_encode($digest);
+        $hmac_list = explode(',', $params['hmac']);
+
+        return in_array($calculated, $hmac_list);
+    }
+
     private function convertBatchRequestsToArray(BatchRequest ...$requests): array
     {
         $requestMapper = function (BatchRequest $request) {

--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1142,6 +1142,17 @@ class Cronofy
 
     public function hmacValid($hmac_header, $body)
     {
+        /* Verifies a HMAC from a push notification using the client secret.
+        
+          String hmac_header: A String containing comma-separated values 
+          describing HMACs of the notification taken from the Cronofy-HMAC-SHA256 header.
+
+          String body: A String of the body of the notification.
+
+          Returns true if one of the HMAC provided matches the one calculated using the
+          client secret, otherwise false.
+         */
+
         if ($hmac_header == null  || empty($hmac_header)) {
             return false;
         }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -721,22 +721,22 @@ class CronofyTest extends TestCase
 
         $body = '{"example":"well-known"}';
 
-        $actual = $cronofy->verifyHMAC("NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==", $body);
+        $actual = $cronofy->hmacValid("NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==", $body);
         $this->assertTrue($actual);
 
-        $actual = $cronofy->verifyHMAC("something-else", $body);
+        $actual = $cronofy->hmacValid("something-else", $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->verifyHMAC("something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2", $body);
+        $actual = $cronofy->hmacValid("something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2", $body);
         $this->assertTrue($actual);
 
-        $actual = $cronofy->verifyHMAC("something-else,something-else2", $body);
+        $actual = $cronofy->hmacValid("something-else,something-else2", $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->verifyHMAC(null, $body);
+        $actual = $cronofy->hmacValid(null, $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->verifyHMAC("", $body);
+        $actual = $cronofy->hmacValid("", $body);
         $this->assertFalse($actual);
     }
 }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -721,22 +721,22 @@ class CronofyTest extends TestCase
 
         $body = '{"example":"well-known"}';
 
-        $actual = $cronofy->hmacMatch(["hmac" => "NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA=="], $body);
+        $actual = $cronofy->verifyHMAC("NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==", $body);
         $this->assertTrue($actual);
 
-        $actual = $cronofy->hmacMatch(["hmac" => "something-else"], $body);
+        $actual = $cronofy->verifyHMAC("something-else", $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->hmacMatch(["hmac" => "something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2"], $body);
+        $actual = $cronofy->verifyHMAC("something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2", $body);
         $this->assertTrue($actual);
 
-        $actual = $cronofy->hmacMatch(["hmac" => "something-else,something-else2"], $body);
+        $actual = $cronofy->verifyHMAC("something-else,something-else2", $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->hmacMatch(null, $body);
+        $actual = $cronofy->verifyHMAC(null, $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->hmacMatch(["hmac" => ""], $body);
+        $actual = $cronofy->verifyHMAC("", $body);
         $this->assertFalse($actual);
     }
 }

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -708,4 +708,35 @@ class CronofyTest extends TestCase
         ]);
         $this->assertNotNull($actual);
     }
+
+    public function testHmacValidation()
+    {
+        $cronofy = new Cronofy([
+            "client_id" => "clientId",
+            "client_secret" => "clientSecret",
+            "access_token" => "accessToken",
+            "refresh_token" => "refreshToken",
+            "http_client" => null,
+        ]);
+
+        $body = '{"example":"well-known"}';
+
+        $actual = $cronofy->hmacMatch(["hmac" => "NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA=="], $body);
+        $this->assertTrue($actual);
+
+        $actual = $cronofy->hmacMatch(["hmac" => "something-else"], $body);
+        $this->assertFalse($actual);
+
+        $actual = $cronofy->hmacMatch(["hmac" => "something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2"], $body);
+        $this->assertTrue($actual);
+
+        $actual = $cronofy->hmacMatch(["hmac" => "something-else,something-else2"], $body);
+        $this->assertFalse($actual);
+
+        $actual = $cronofy->hmacMatch(null, $body);
+        $this->assertFalse($actual);
+
+        $actual = $cronofy->hmacMatch(["hmac" => ""], $body);
+        $this->assertFalse($actual);
+    }
 }


### PR DESCRIPTION
New hmacMatch function that will verify that the proper HMAC has been passed. Users can pass multiple HMACS into a string, where those are separated by commas. If any of them matches, then return true, otherwise false.
Added multiple tests to cover:

- Right HMAC being passed
- Wrong HMAC being passed
- Multiple HMACs being passed where only one of them is an entitled HMAC
- Multiple wrong HMACS
- NULL HMAC
- Empty HMAC