### PR TITLE
add include_ics as optional param to getSmartInvite method

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -950,7 +950,7 @@ class Cronofy
         return $this->apiKeyHttpPost("/" . self::API_VERSION . "/smart_invites", $postFields);
     }
 
-    public function getSmartInvite($smart_invite_id, $recipient_email)
+    public function getSmartInvite($smart_invite_id, $recipient_email, $include_ics = false)
     {
         /*
           String smart_invite_id: A string representing the id for the smart invite. REQUIRED
@@ -960,6 +960,7 @@ class Cronofy
         $urlParams = [
             "smart_invite_id" => $smart_invite_id,
             "recipient_email" => $recipient_email,
+            "include_ics" => $include_ics,
         ];
 
         return $this->apiKeyHttpGet("/" . self::API_VERSION . "/smart_invites", $urlParams);


### PR DESCRIPTION
as described here https://docs.cronofy.com/developers/api/smart-invites/invite-status/ this method should include `invite_ics` optional param