### PR TITLE
Output binary data from HMAC hashing function

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1226,7 +1226,7 @@ class Cronofy
             return false;
         }
 
-        $digest = hash_hmac('sha256', $body, $this->clientSecret);
+        $digest = hash_hmac('sha256', $body, $this->clientSecret, true);
         $calculated = base64_encode($digest);
         $hmac_list = explode(',', $hmac_header);
 

--- a/tests/CronofyTest.php
+++ b/tests/CronofyTest.php
@@ -721,13 +721,13 @@ class CronofyTest extends TestCase
 
         $body = '{"example":"well-known"}';
 
-        $actual = $cronofy->hmacValid("NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==", $body);
+        $actual = $cronofy->hmacValid("QuGlxxssNDaxUjd6RY4wxGf+5KDrmobMmjkGQPtB3WQ=", $body);
         $this->assertTrue($actual);
 
         $actual = $cronofy->hmacValid("something-else", $body);
         $this->assertFalse($actual);
 
-        $actual = $cronofy->hmacValid("something-else,NDJlMWE1YzcxYjJjMzQzNmIxNTIzNzdhNDU4ZTMwYzQ2N2ZlZTRhMGViOWE4NmNjOWEzOTA2NDBmYjQxZGQ2NA==,something-else2", $body);
+        $actual = $cronofy->hmacValid("something-else,QuGlxxssNDaxUjd6RY4wxGf+5KDrmobMmjkGQPtB3WQ=", $body);
         $this->assertTrue($actual);
 
         $actual = $cronofy->hmacValid("something-else,something-else2", $body);


### PR DESCRIPTION
The push notification payloads from Cronofy include base64 encoded **binary** data. This PR makes the check match what we receive from Cronofy.

Fixes #112