### PR TITLE
Add return type will change to iterator

### DIFF
--- a/src/PagedResultIterator.php
+++ b/src/PagedResultIterator.php
@@ -38,6 +38,7 @@ class PagedResultIterator implements \IteratorAggregate
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->each();


### PR DESCRIPTION
#[\ReturnTypeWillChange] is required to avoid php notices on recent php versions