### PR TITLE
avoid errors for non 0 indexed arrays

### DIFF
--- a/src/Cronofy.php
+++ b/src/Cronofy.php
@@ -1268,8 +1268,8 @@ class Cronofy
 
         foreach ($params as $key => $val) {
             if (gettype($val) == "array") {
-                for ($i = 0; $i < count($val); $i++) {
-                    array_push($str_params, $key . "[]=" . urlencode($val[$i]));
+                foreach ($val as $v) {
+                    array_push($str_params, $key . "[]=" . urlencode($v));
                 }
             } elseif (gettype($val) == "boolean") {
                 $bool_str = $val ? "true" : "false";


### PR DESCRIPTION
if you have an array like

[
1 => 'something',
2 => 'something else',
]

for example, after array_unique or array_filter, then current code doesn't work. foreach will happily iterate on any values and seems a safer option

(had the issue on my project, fixed it upstream by ensuring a properly 0 indexed array, but that seems good to have nonetheless)